### PR TITLE
chore: bootstrap repo structure and documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Server
+PORT=8080
+JWT_SECRET=change_me
+DATABASE_URL=postgresql://app:app@db:5432/app
+REDIS_URL=redis://redis:6379
+
+# OpenAI (nur Worker)
+OPENAI_API_KEY=
+OPENAI_DAILY_BUDGET_USD=2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.bat text eol=crlf
+*.ps1 text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,47 @@
-# Gradle files
-.gradle/
+# OS
+.DS_Store
+Thumbs.db
+
+# Editors
+.vscode/
+.idea/
+
+# Node
+node_modules/
+npm-debug.log*
+pnpm-lock.yaml
+yarn.lock
+dist/
 build/
 
-# Local configuration file (sdk path, etc)
-local.properties
-
-# Log/OS Files
-*.log
-
-# Android Studio generated files and folders
-captures/
-.externalNativeBuild/
-.cxx/
-*.aab
+# Unity
+[Ll]ibrary/
+[Tt]emp/
+[Oo]bj/
+[Bb]uild*/
+[Ll]ogs/
+[Mm]emoryCaptures/
+UserSettings/
+*.csproj
+*.sln
+*.unityproj
+*.pidb
+*.user
+*.booproj
+*.svd
+*.pdb
+*.ldb
+*.opendb
 *.apk
-output-metadata.json
+*.aab
 
-# IntelliJ
+# Docker
+*.env
+.env.local
+.env.production
+.env.development
+
+# Misc
 *.iml
-.idea/
-misc.xml
-deploymentTargetDropDown.xml
-render.experimental.xml
-
-# Keystore files
-*.jks
-*.keystore
-
-# Google Services (e.g. APIs or Firebase)
-google-services.json
-
-# Android Profiling
-*.hprof
+*.swp
+*.orig

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# mobile-infinite-runner-android
+
+Ziel: Mobile Infinite Runner. Erst Android, später iOS. Heimserver mit fester IP liefert Level, verifiziert Runs, hostet Leaderboards.
+
+Komponenten:
+- `apps/mobile`: Unity 2D Android Client.
+- `server/api`: Fastify API mit JWT.
+- `server/worker`: BullMQ Worker für Gen-Test-Tune.
+- `server/packages/game-spec`: Zod-Schemas, Progression, Biomes.
+- `server/packages/sim`: deterministische TS-Simulation.
+- `ops`: Docker Compose, Caddy, Runbooks, Diagramme.
+
+Start-Roadmap:
+1. Repo und Docs.
+2. Ops Skeleton mit Compose und Caddy.
+3. API Skeleton mit /health.
+4. Unity-Projekt, 60 FPS Loop, HTTP Ping.
+5. Replay-Verification Hello World.
+
+Lizenz: privat vorerst.

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,1 @@
+Unity 2D Android Client. Task 4 erstellt das Projekt im Ordner `apps/mobile`.

--- a/ops/caddy/Caddyfile
+++ b/ops/caddy/Caddyfile
@@ -1,0 +1,1 @@
+# Platzhalter, wird in Task 2 gefüllt

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -1,0 +1,1 @@
+# Platzhalter, wird in Task 2 gefüllt

--- a/ops/docs/AGENTS.md
+++ b/ops/docs/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS
+
+## Codex Leitfaden
+Zweck: Aufgaben in kleinen, deterministischen Schritten abarbeiten. Keine globale Suche nötig. Datei- und Ordnerkarten unten.
+
+## Ordnerkarten
+- apps/mobile: Unity Client. Szenen, Prefabs, Scripts.
+- server/api: Fastify-Routen, Zod-Schemas, JWT, DB-Zugriff.
+- server/worker: BullMQ Queues, Jobs gen-test-tune, OpenAI-Kostenwächter.
+- server/packages/game-spec: gemeinsame Typen und Regeln.
+- server/packages/sim: deterministische Lauf-Simulation.
+- ops/caddy: Caddyfile für TLS und Reverse Proxy.
+- ops/docs: Runbooks und Diagramme.
+
+## Arbeitsregeln
+- Typescript strikt. Zod für IO-Validierung.
+- API ist read-only für Levels und Leaderboard in v0.
+- Replays sind Input-Deltas, Server verifiziert via `sim`.
+- Rate-Limits im Proxy, zusätzliche Limits in API.

--- a/ops/docs/DIAGRAMS.md
+++ b/ops/docs/DIAGRAMS.md
@@ -1,0 +1,10 @@
+# Diagramme
+
+## High-Level
+Android App ⇄ HTTPS ⇄ Caddy ⇄ API
+                           ⇓
+                       Redis + BullMQ
+                           ⇓
+                        Worker (Gen/Test/Tune, OpenAI)
+                           ⇓
+                 Postgres + Object Storage (Replays)

--- a/ops/docs/RUNBOOK.md
+++ b/ops/docs/RUNBOOK.md
@@ -1,0 +1,21 @@
+# RUNBOOK
+
+## Voraussetzungen Dev
+- Windows 10/11
+- Git, Node.js 22 LTS, Docker Desktop
+- Unity Hub + Unity 2022 LTS oder 2023 LTS
+
+## Branching
+- main: stabil
+- feat/*: Features
+- fix/*: Hotfixes
+
+## Commits
+- Conventional Commits: feat, fix, chore, docs, refactor, test, ci
+
+## Secrets
+- Niemals `.env` einchecken. Beispiel siehe `.env.example`.
+
+## Aufgabenfluss
+- Jede Aufgabe als Issue mit Akzeptanzkriterien.
+- PR mit CI-Checks. Code-Review Pflicht bei API und Worker.

--- a/server/api/README.md
+++ b/server/api/README.md
@@ -1,0 +1,1 @@
+API Skeleton. Wird in Task 3 aufgebaut: Fastify, Zod, JWT, /health, /levels, /runs stub.

--- a/server/packages/game-spec/README.md
+++ b/server/packages/game-spec/README.md
@@ -1,0 +1,1 @@
+Gemeinsame Typen und Spielregeln. Wird in Task 5 gefüllt.

--- a/server/packages/sim/README.md
+++ b/server/packages/sim/README.md
@@ -1,0 +1,1 @@
+Deterministische Simulation. Wird in Task 5 gefüllt.

--- a/server/worker/README.md
+++ b/server/worker/README.md
@@ -1,0 +1,1 @@
+Worker Skeleton. Wird in Task 4 aufgebaut: BullMQ Queues, Jobs, Budget-Guard.


### PR DESCRIPTION
## Summary
- add repository documentation, ignore rules, and environment example
- scaffold app, server, and ops directories with placeholder readmes and configs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df832aea88832dbd95ecfd236c872e