### PR TITLE
Add ops compose stack with Caddy TLS and health service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,12 @@ REDIS_URL=redis://redis:6379
 # OpenAI (nur Worker)
 OPENAI_API_KEY=
 OPENAI_DAILY_BUDGET_USD=2
+
+# --- TLS / Domain ---
+CADDY_DOMAIN=game.example.com
+CADDY_EMAIL=you@example.com
+
+# --- Postgres ---
+POSTGRES_USER=app
+POSTGRES_PASSWORD=app
+POSTGRES_DB=app

--- a/ops/caddy/Caddyfile
+++ b/ops/caddy/Caddyfile
@@ -1,1 +1,33 @@
-# Platzhalter, wird in Task 2 gefüllt
+{
+  email {$CADDY_EMAIL}
+  # Optional: global logging
+  # admin off
+}
+
+{$CADDY_DOMAIN} {
+  encode gzip zstd
+
+  @health path /health
+  reverse_proxy @health health:80
+
+  # Fallback bis API existiert
+  handle {
+    respond 404
+  }
+
+  header {
+    Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+    X-Content-Type-Options "nosniff"
+    X-Frame-Options "DENY"
+    Referrer-Policy "no-referrer"
+  }
+
+  tls {
+    # HTTP-01 default; falls CGNAT → später DNS-01 umstellen
+  }
+
+  log {
+    output stdout
+    format json
+  }
+}

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -1,1 +1,49 @@
-# Platzhalter, wird in Task 2 gefüllt
+version: "3.9"
+
+name: mobile-infinite-runner-android
+
+services:
+  caddy:
+    image: caddy:2.8
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - CADDY_DOMAIN=${CADDY_DOMAIN}
+      - CADDY_EMAIL=${CADDY_EMAIL}
+    volumes:
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - health
+
+  health:
+    image: nginx:alpine
+    restart: unless-stopped
+    volumes:
+      - ./health/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis_data:/data
+
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+volumes:
+  caddy_data:
+  caddy_config:
+  redis_data:
+  db_data:

--- a/ops/docs/RUNBOOK.md
+++ b/ops/docs/RUNBOOK.md
@@ -19,3 +19,41 @@
 ## Aufgabenfluss
 - Jede Aufgabe als Issue mit Akzeptanzkriterien.
 - PR mit CI-Checks. Code-Review Pflicht bei API und Worker.
+
+## Deployment Heimserver (Phase 0)
+
+1) DNS
+- A-Record `CADDY_DOMAIN` → feste öffentliche IP des Heimanschlusses.
+- TTL 300s für schnellen Rollout.
+
+2) Router / Firewall
+- Port-Forward: WAN 80→LAN:80 (Server), WAN 443→LAN:443 (Server).
+- Hairpin NAT aktivieren/testen, falls Clients im gleichen LAN die Domain nutzen.
+
+3) .env
+- Im Repo-Root `.env` aus `.env.example` kopieren.
+- `CADDY_DOMAIN`, `CADDY_EMAIL`, `POSTGRES_*` setzen.
+
+4) Start
+```bash
+cd ops
+docker compose pull
+docker compose up -d
+```
+
+
+Validierung
+
+DNS: nslookup $CADDY_DOMAIN
+
+HTTP: curl -I http://$CADDY_DOMAIN/health → 301/308 Redirect auf HTTPS
+
+HTTPS: curl -I https://$CADDY_DOMAIN/health → 200 OK
+
+Caddy-Logs: docker logs -n 200 ops-caddy-1 (Name kann abweichen)
+
+Hinweise
+
+Bei CGNAT schlägt HTTP-01 fehl. Lösung: statische IP buchen oder DNS-01 (Caddy tls mit DNS Provider).
+
+Nur 80/443 nach außen öffnen. Admin-Ports nicht exponieren.

--- a/ops/health/nginx.conf
+++ b/ops/health/nginx.conf
@@ -1,0 +1,14 @@
+server {
+  listen 80 default_server;
+  server_name _;
+
+  location = /health {
+    default_type application/json;
+    add_header Cache-Control "no-store";
+    return 200 '{"status":"ok","service":"health","ts":"$time_iso8601"}';
+  }
+
+  location / {
+    return 404;
+  }
+}


### PR DESCRIPTION
## Summary
- add docker compose stack for Caddy, health proxy, Redis, and Postgres
- configure Caddy for automatic TLS and proxying the health endpoint
- document deployment steps and sample environment variables for TLS and database

## Testing
- docker compose config *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df84c09744832d959e6983fba3d7f1